### PR TITLE
Fix framework name(case-sensitive) of JavaScriptCore, for link error …

### DIFF
--- a/MOBFoundation.podspec
+++ b/MOBFoundation.podspec
@@ -7,7 +7,7 @@ s.author              = { "Jinghuang Liu" => "liujinghuang@icloud.com" }
 s.homepage            = 'http://www.mob.com'
 s.source              = { :git => "https://github.com/ShareSDKPlatform/MOBFoundation.git", :tag => s.version.to_s }
 s.platform            = :ios, '6.0'
-s.frameworks          = "javascriptcore"
+s.frameworks          = "JavaScriptCore"
 s.libraries           = "icucore", "z", "stdc++"
 s.vendored_frameworks = 'MOBFoundation.framework'
 end


### PR DESCRIPTION
…when using ShareSDK2 on case-sensitive filesystem: ld: framework not found javascriptcore.

It is 'JavaScriptCore', not 'javascriptcore', you may check by this command:
`ls -d /System/Library/Frameworks/JavaScriptCore.framework/`
