### PR TITLE
Fix sharedInstance warning

### DIFF
--- a/MOBFoundation.framework/Headers/MOBFImageGetter.h
+++ b/MOBFoundation.framework/Headers/MOBFImageGetter.h
@@ -22,7 +22,7 @@
  *
  *  @return 图片服务实例
  */
-+ (instancetype)sharedInstance;
++ (nonnull MOBFImageGetter *)sharedInstance;
 
 /**
  初始化图片服务实例


### PR DESCRIPTION
A singleton should not return null and shouldn't be subclassable.

This pull request fixes a Clang warning in Xcode and applies strict typing for the singleton pattern.